### PR TITLE
災危通報の表示について調整

### DIFF
--- a/gokigen_geo_location/ShowDCIS.hpp
+++ b/gokigen_geo_location/ShowDCIS.hpp
@@ -158,7 +158,7 @@ public:
     }
 
     // ----- 災危通報の表示
-    M5.Display.setCursor(0,20);
+    M5.Display.setCursor(0,22);
     M5.Display.setTextSize(1);
     M5.Display.setTextColor(TFT_WHITE, TFT_BLACK);
     M5.Display.setFont(&fonts::efontJA_16);
@@ -171,16 +171,16 @@ public:
     M5.Display.printf("受信メッセージ： %3d/%3d\r\n", (_messageIndex + 1), messageCount);
 
     // ----- メッセージの移動タッチ位置のマーク
-    M5.Display.drawLine(224, 28, 239, 43);
-    M5.Display.fillTriangle(224, 35, 239, 28, 239, 43);
+    M5.Display.fillTriangle(257, 35, 272, 28, 272, 43, TFT_WHITE);
+   M5.Display.drawLine(257, 27, 257, 43);
     //M5.Display.drawRect(224,28, 15,15, TFT_WHITE);
 
     M5.Display.setFont(&fonts::efontJA_14);
-    M5.Display.setCursor(265,29);
+    M5.Display.setCursor(281,29);
     M5.Display.printf("今");
-    M5.Display.drawRect(264,28, 15,15, TFT_WHITE);
+    M5.Display.drawRect(280,27, 16,16, TFT_WHITE);
 
-    M5.Display.drawLine(319, 28, 319, 43);
+    M5.Display.drawLine(319, 27, 319, 43);
     M5.Display.fillTriangle(319, 35, 304, 28, 304, 43);
     //M5.Display.drawRect(304,28, 15,15, TFT_WHITE);
 
@@ -192,7 +192,7 @@ public:
     if (!_isDumped)
     {
       _applyFontSize();
-      M5.Display.setCursor(0,45);
+      M5.Display.setCursor(0,48);
       M5.Display.setTextSize(1);
       displayCurrentJstTime("受信日時： ", messageParser->getQZSSdcrReceivedDateTime(_messageIndex));
       _doDecodeAndDisplay(messageParser->getQZSSdcrMessage(_messageIndex));
@@ -217,19 +217,19 @@ public:
         }
         _makeVibration = true;
       }
-      else if ((posX > 280)&&(posY > 27)&&(posY < 60))
+      else if ((posX > 304)&&(posY > 27)&&(posY < 60))
       {
         // ----- 受信メッセージ数の横あたりの右 : 末尾の場所に
         _messageIndex = messageCount - 1;
         _makeVibration = true;
       }
-      else if ((posX > 250)&&(posX < 275)&&(posY > 27)&&(posY < 60))
+      else if ((posX > 275)&&(posX < 300)&&(posY > 27)&&(posY < 60))
       {
         // ----- 受信メッセージ数の横あたりの中 : 最新の場所に
         _messageIndex = messageParser->getLastMessageIndex() - 1;
         _makeVibration = true;
       }
-      else if ((posX > 220)&&(posX < 245)&&(posY > 27)&&(posY < 60))
+      else if ((posX > 250)&&(posX < 275)&&(posY > 27)&&(posY < 60))
       {
         // ----- 受信メッセージ数の横あたりの左 : 先頭に
 

--- a/gokigen_geo_location/ShowDCIS.hpp
+++ b/gokigen_geo_location/ShowDCIS.hpp
@@ -171,11 +171,18 @@ public:
     M5.Display.printf("受信メッセージ： %3d/%3d\r\n", (_messageIndex + 1), messageCount);
 
     // ----- メッセージの移動タッチ位置のマーク
-    //M5.Display.setCursor(308,0);
-    //M5.Display.printf("F");
-    M5.Display.drawRect(304,30, 15,15, TFT_WHITE);
-    M5.Display.drawRect(264,30, 15,15, TFT_WHITE);
-    M5.Display.drawRect(224,30, 15,15, TFT_WHITE);
+    M5.Display.drawLine(224, 28, 239, 43);
+    M5.Display.fillTriangle(224, 35, 239, 28, 239, 43);
+    //M5.Display.drawRect(224,28, 15,15, TFT_WHITE);
+
+    M5.Display.setFont(&fonts::efontJA_14);
+    M5.Display.setCursor(265,29);
+    M5.Display.printf("今");
+    M5.Display.drawRect(264,28, 15,15, TFT_WHITE);
+
+    M5.Display.drawLine(319, 28, 319, 43);
+    M5.Display.fillTriangle(319, 35, 304, 28, 304, 43);
+    //M5.Display.drawRect(304,28, 15,15, TFT_WHITE);
 
     // ----- メッセージのフォントサイズを決定する
 
@@ -210,19 +217,19 @@ public:
         }
         _makeVibration = true;
       }
-      else if ((posX > 280)&&(posY > 30)&&(posY < 60))
+      else if ((posX > 280)&&(posY > 27)&&(posY < 60))
       {
         // ----- 受信メッセージ数の横あたりの右 : 末尾の場所に
         _messageIndex = messageCount - 1;
         _makeVibration = true;
       }
-      else if ((posX > 250)&&(posX < 275)&&(posY > 30)&&(posY < 60))
+      else if ((posX > 250)&&(posX < 275)&&(posY > 27)&&(posY < 60))
       {
         // ----- 受信メッセージ数の横あたりの中 : 最新の場所に
         _messageIndex = messageParser->getLastMessageIndex() - 1;
         _makeVibration = true;
       }
-      else if ((posX > 220)&&(posX < 245)&&(posY > 30)&&(posY < 60))
+      else if ((posX > 220)&&(posX < 245)&&(posY > 27)&&(posY < 60))
       {
         // ----- 受信メッセージ数の横あたりの左 : 先頭に
 

--- a/gokigen_geo_location/UbxMessageParser.hpp
+++ b/gokigen_geo_location/UbxMessageParser.hpp
@@ -82,7 +82,7 @@ private:
     // --------- 受信した QZSSメッセージを保管しておくかどうか判断する
     uint8_t numWords = _ubxMessageBuffer[10];   // ワード数
     uint8_t dcr[numWords * 4];                  // サブフレームデータの格納先
-    for (int i = 0; i < numWords * 4; i += 4) // 1ワードごとに処理
+    for (int i = 0; i < numWords * 4; i += 4)   // 1ワードごとに処理
     {
       dcr[i + 0] = _ubxMessageBuffer[14 + i + 3];
       dcr[i + 1] = _ubxMessageBuffer[14 + i + 2];
@@ -210,9 +210,10 @@ public:
       struct tm currentTime;
       getLocalTime(&currentTime);
       memcpy(&_QZSSdcrReceiveDateTime[_nofDcrMessageIndex], &currentTime, sizeof(struct tm));
-
-      Serial.print("  STORE : "); Serial.print(totalMessageLength); Serial.println(" bytes.");
       _nofDcrMessageIndex++;
+
+      Serial.print("  STORE : "); Serial.print(totalMessageLength); Serial.print(" bytes.  ");
+      Serial.print(_nofDcrMessageIndex); Serial.print("/"); Serial.println(_nofDcrMessage);
       if (_nofDcrMessage < MAX_STORE_MESSAGE_SIZE)
       {
         // 保管メッセージ数をインクリメント（最大数までたまっていたら更新しない）

--- a/gokigen_geo_location/UbxMessageParser.hpp
+++ b/gokigen_geo_location/UbxMessageParser.hpp
@@ -3,8 +3,7 @@
 // UBXメッセージの最大長を定義
 // (QZSSメッセージは長くなる可能性があるらしい)
 #define UBX_BUFFER_SIZE 280
-#define MAX_STORE_MESSAGE_SIZE 600  // 過去のメッセージ保持数
-#define MD5_HASH_BUFFER_SIZE 16
+#define MAX_STORE_MESSAGE_SIZE 800  // 過去のメッセージ保持数
 class UbxMessageParser
 {
 private:
@@ -14,8 +13,8 @@ private:
   int _currentUbxMessageIndex = 0;
   uint8_t _ubxMessageBuffer[UBX_BUFFER_SIZE + 1];
 
-  uint8_t _nofDcrMessage = 0;
-  uint8_t _nofDcrMessageIndex = 0;
+  uint16_t _nofDcrMessage = 0;
+  uint16_t _nofDcrMessageIndex = 0;
   uint8_t _QZSSdcrMessage[MAX_STORE_MESSAGE_SIZE][UBX_BUFFER_SIZE + 1];
   struct tm _QZSSdcrReceiveDateTime[MAX_STORE_MESSAGE_SIZE];
 


### PR DESCRIPTION
災危通報の表示について調整する。

最大数を増加さえ、メッセージの先頭、末尾、現在へのジャンプをできるようにする。
